### PR TITLE
Add quick build hotkeys for structures and nukes

### DIFF
--- a/resources/lang/debug.json
+++ b/resources/lang/debug.json
@@ -21,6 +21,7 @@
     "action_alt_view": "help_modal.action_alt_view",
     "action_attack_altclick": "help_modal.action_attack_altclick",
     "action_build": "help_modal.action_build",
+    "action_quick_build": "help_modal.action_quick_build",
     "action_center": "help_modal.action_center",
     "action_zoom": "help_modal.action_zoom",
     "action_move_camera": "help_modal.action_move_camera",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -37,6 +37,7 @@
     "action_alt_view": "Alternate view (terrain/countries)",
     "action_attack_altclick": "Attack (when left click is set to open menu)",
     "action_build": "Open build menu",
+    "action_quick_build": "Quick build units (hold shortcut + left click: 3=Port, 4=City, 5=Factory, 6=Defense Post, 7=SAM Launcher, 8=Missile Silo, 9=Warship, 0=Atom Bomb, H=Hydrogen Bomb)",
     "action_emote": "Open emote menu",
     "action_center": "Center camera on player",
     "action_zoom": "Zoom out/in",

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -84,6 +84,19 @@ export class HelpModal extends LitElement {
               <tr>
                 <td>
                   <div class="scroll-combo-horizontal">
+                    <span class="key">3-9, 0, H</span>
+                    <span class="plus">+</span>
+                    <div class="mouse-shell alt-left-click">
+                      <div class="mouse-left-corner"></div>
+                      <div class="mouse-wheel"></div>
+                    </div>
+                  </div>
+                </td>
+                <td>${translateText("help_modal.action_quick_build")}</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="scroll-combo-horizontal">
                     <span class="key">${getAltKey()}</span>
                     <span class="plus">+</span>
                     <div class="mouse-shell alt-left-click">

--- a/tests/client/graphics/BuildMenuQuickBuild.test.ts
+++ b/tests/client/graphics/BuildMenuQuickBuild.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("lit", () => {
+  class MockLitElement {
+    requestUpdate() {}
+  }
+  return {
+    LitElement: MockLitElement,
+    html: () => "",
+    css: () => "",
+  };
+});
+
+jest.mock("lit/decorators.js", () => ({
+  customElement: () => () => undefined,
+  state: () => () => undefined,
+}));
+
+jest.mock("../../../src/client/Transport", () => ({
+  BuildUnitIntentEvent: class BuildUnitIntentEvent {
+    unit: unknown;
+    tile: unknown;
+
+    constructor(unit: unknown, tile: unknown) {
+      this.unit = unit;
+      this.tile = tile;
+    }
+  },
+  SendUpgradeStructureIntentEvent: class SendUpgradeStructureIntentEvent {
+    unitId: unknown;
+    unitType: unknown;
+
+    constructor(unitId: unknown, unitType: unknown) {
+      this.unitId = unitId;
+      this.unitType = unitType;
+    }
+  },
+}));
+
+import { BuildMenu } from "../../../src/client/graphics/layers/BuildMenu";
+import { QuickBuildEvent } from "../../../src/client/InputHandler";
+import { BuildUnitIntentEvent } from "../../../src/client/Transport";
+import { EventBus } from "../../../src/core/EventBus";
+import {
+  BuildableUnit,
+  PlayerActions,
+  UnitType,
+} from "../../../src/core/game/Game";
+import { TileRef } from "../../../src/core/game/GameMap";
+import { GameView, PlayerView } from "../../../src/core/game/GameView";
+
+describe("BuildMenu quick build", () => {
+  function setupQuickBuildTest(overrides: Partial<BuildableUnit> = {}) {
+    const eventBus = new EventBus();
+    const buildMenu = new BuildMenu();
+    // Prevent Lit from scheduling renders during tests
+    (buildMenu as unknown as { requestUpdate: () => void }).requestUpdate =
+      jest.fn();
+
+    const tile = 321 as TileRef;
+    const buildableUnit: BuildableUnit = {
+      type: overrides.type ?? UnitType.Port,
+      canBuild: overrides.canBuild ?? tile,
+      canUpgrade: overrides.canUpgrade ?? false,
+      cost: overrides.cost ?? 0n,
+    };
+
+    const refMock = jest.fn(() => tile);
+    const actionsMock = jest.fn<Promise<PlayerActions>, [TileRef]>(() =>
+      Promise.resolve({
+        canAttack: false,
+        canSendEmojiAllPlayers: false,
+        buildableUnits: [buildableUnit],
+      }),
+    );
+
+    const player = {
+      isAlive: () => true,
+      actions: actionsMock,
+    } as unknown as PlayerView;
+
+    const game = {
+      myPlayer: () => player,
+      isValidCoord: jest.fn(() => true),
+      ref: refMock,
+      config: () => ({ isUnitDisabled: () => false }),
+    } as unknown as GameView;
+
+    const transformHandler = {
+      screenToWorldCoordinates: jest.fn(() => ({ x: 4, y: 5 })),
+    } as any;
+
+    buildMenu.game = game;
+    buildMenu.eventBus = eventBus;
+    buildMenu.transformHandler = transformHandler;
+
+    buildMenu.init();
+
+    return { eventBus, buildMenu, actionsMock, refMock, tile, buildableUnit };
+  }
+
+  it("emits a build intent when the quick build hotkey is available", async () => {
+    const { eventBus, actionsMock, refMock, tile, buildableUnit } =
+      setupQuickBuildTest();
+
+    const emitSpy = jest.spyOn(eventBus, "emit");
+    eventBus.emit(new QuickBuildEvent(buildableUnit.type, 10, 20));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(actionsMock).toHaveBeenCalledWith(tile);
+    expect(refMock).toHaveBeenCalledWith(4, 5);
+
+    const buildEventCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof BuildUnitIntentEvent,
+    );
+    expect(buildEventCall).toBeDefined();
+    const buildEvent = buildEventCall![0] as BuildUnitIntentEvent;
+    expect(buildEvent.unit).toBe(buildableUnit.type);
+    expect(buildEvent.tile).toBe(tile);
+  });
+
+  it("does not emit when the structure cannot be built or upgraded", async () => {
+    const { eventBus, buildableUnit } = setupQuickBuildTest({
+      canBuild: false,
+      canUpgrade: false,
+    });
+
+    const emitSpy = jest.spyOn(eventBus, "emit");
+    eventBus.emit(new QuickBuildEvent(buildableUnit.type, 10, 20));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const buildEventCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof BuildUnitIntentEvent,
+    );
+    expect(buildEventCall).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add digit 3-9, 0, and H hotkeys that trigger quick build events for structures, the warship, and nukes without opening the menu
- handle quick build requests in the build menu and document the shortcuts in the help modal
- cover the quick build workflow with a focused unit test

## Testing
- npm test -- BuildMenuQuickBuild.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc7ef3b3f8833396b069998e116008