### PR TITLE
Add quick build hotkeys for structures and nukes

### DIFF
--- a/resources/lang/debug.json
+++ b/resources/lang/debug.json
@@ -21,6 +21,7 @@
     "action_alt_view": "help_modal.action_alt_view",
     "action_attack_altclick": "help_modal.action_attack_altclick",
     "action_build": "help_modal.action_build",
+    "action_quick_build": "help_modal.action_quick_build",
     "action_center": "help_modal.action_center",
     "action_zoom": "help_modal.action_zoom",
     "action_move_camera": "help_modal.action_move_camera",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -37,6 +37,7 @@
     "action_alt_view": "Alternate view (terrain/countries)",
     "action_attack_altclick": "Attack (when left click is set to open menu)",
     "action_build": "Open build menu",
+    "action_quick_build": "Quick build units (hold shortcut + left click: 3=Port, 4=City, 5=Factory, 6=Defense Post, 7=SAM Launcher, 8=Missile Silo, 9=Warship, 0=Atom Bomb, H=Hydrogen Bomb)",
     "action_emote": "Open emote menu",
     "action_center": "Center camera on player",
     "action_zoom": "Zoom out/in",

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -84,6 +84,19 @@ export class HelpModal extends LitElement {
               <tr>
                 <td>
                   <div class="scroll-combo-horizontal">
+                    <span class="key">3-9, 0, H</span>
+                    <span class="plus">+</span>
+                    <div class="mouse-shell alt-left-click">
+                      <div class="mouse-left-corner"></div>
+                      <div class="mouse-wheel"></div>
+                    </div>
+                  </div>
+                </td>
+                <td>${translateText("help_modal.action_quick_build")}</td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="scroll-combo-horizontal">
                     <span class="key">${getAltKey()}</span>
                     <span class="plus">+</span>
                     <div class="mouse-shell alt-left-click">

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -78,6 +78,21 @@ export class ToggleStructureEvent implements GameEvent {
   constructor(public readonly structureType: UnitType | null) {}
 }
 
+export class QuickBuildEvent implements GameEvent {
+  constructor(
+    public readonly unitType: UnitType,
+    public readonly x: number,
+    public readonly y: number,
+  ) {}
+}
+
+export class QuickBuildFailedEvent implements GameEvent {
+  constructor(
+    public readonly x: number,
+    public readonly y: number,
+  ) {}
+}
+
 export class ShowBuildMenuEvent implements GameEvent {
   constructor(
     public readonly x: number,
@@ -132,6 +147,28 @@ export class InputHandler {
   private moveInterval: NodeJS.Timeout | null = null;
   private activeKeys = new Set<string>();
   private keybinds: Record<string, string> = {};
+  private readonly quickBuildHotkeys = new Map<string, UnitType>([
+    ["Digit3", UnitType.Port],
+    ["Digit4", UnitType.City],
+    ["Digit5", UnitType.Factory],
+    ["Digit6", UnitType.DefensePost],
+    ["Digit7", UnitType.SAMLauncher],
+    ["Digit8", UnitType.MissileSilo],
+    ["Digit9", UnitType.Warship],
+    ["Digit0", UnitType.AtomBomb],
+    ["KeyH", UnitType.HydrogenBomb],
+  ]);
+
+  private pendingQuickBuild: UnitType | null = null;
+  private lastQuickBuildAttempt: { x: number; y: number } | null = null;
+  private readonly handleQuickBuildFailure = (event: QuickBuildFailedEvent) => {
+    if (this.lastQuickBuildAttempt === null) {
+      return;
+    }
+
+    this.eventBus.emit(new MouseUpEvent(event.x, event.y));
+    this.lastQuickBuildAttempt = null;
+  };
 
   private readonly PAN_SPEED = 5;
   private readonly ZOOM_SPEED = 10;
@@ -289,7 +326,8 @@ export class InputHandler {
           "ControlRight",
           "ShiftLeft",
           "ShiftRight",
-        ].includes(e.code)
+        ].includes(e.code) ||
+        this.quickBuildHotkeys.has(e.code)
       ) {
         this.activeKeys.add(e.code);
       }
@@ -341,9 +379,13 @@ export class InputHandler {
 
       this.activeKeys.delete(e.code);
     });
+
+    this.eventBus.on(QuickBuildFailedEvent, this.handleQuickBuildFailure);
   }
 
   private onPointerDown(event: PointerEvent) {
+    this.lastQuickBuildAttempt = null;
+
     if (event.button === 1) {
       event.preventDefault();
       this.eventBus.emit(new AutoUpgradeEvent(event.clientX, event.clientY));
@@ -353,6 +395,9 @@ export class InputHandler {
     if (event.button > 0) {
       return;
     }
+
+    this.pendingQuickBuild =
+      event.pointerType === "touch" ? null : this.getActiveQuickBuildUnitType();
 
     this.pointerDown = true;
     this.pointers.set(event.pointerId, event);
@@ -379,6 +424,10 @@ export class InputHandler {
     if (event.button > 0) {
       return;
     }
+
+    const quickBuildCandidate =
+      event.pointerType === "touch" ? null : this.pendingQuickBuild;
+    this.pendingQuickBuild = null;
     this.pointerDown = false;
     this.pointers.clear();
 
@@ -395,6 +444,21 @@ export class InputHandler {
       Math.abs(event.x - this.lastPointerDownX) +
       Math.abs(event.y - this.lastPointerDownY);
     if (dist < 10) {
+      if (event.pointerType !== "touch") {
+        const quickBuildType =
+          quickBuildCandidate ?? this.getActiveQuickBuildUnitType();
+        if (quickBuildType !== null) {
+          this.lastQuickBuildAttempt = {
+            x: event.clientX,
+            y: event.clientY,
+          };
+          this.eventBus.emit(
+            new QuickBuildEvent(quickBuildType, event.clientX, event.clientY),
+          );
+          return;
+        }
+      }
+
       if (event.pointerType === "touch") {
         this.eventBus.emit(new ContextMenuEvent(event.clientX, event.clientY));
         event.preventDefault();
@@ -548,11 +612,23 @@ export class InputHandler {
     };
   }
 
+  private getActiveQuickBuildUnitType(): UnitType | null {
+    for (const [code, unitType] of this.quickBuildHotkeys) {
+      if (this.activeKeys.has(code)) {
+        return unitType;
+      }
+    }
+    return null;
+  }
+
   destroy() {
     if (this.moveInterval !== null) {
       clearInterval(this.moveInterval);
     }
+    this.eventBus.off(QuickBuildFailedEvent, this.handleQuickBuildFailure);
     this.activeKeys.clear();
+    this.pendingQuickBuild = null;
+    this.lastQuickBuildAttempt = null;
   }
 
   isModifierKeyPressed(event: PointerEvent): boolean {

--- a/tests/client/InputHandlerQuickBuildFallback.test.ts
+++ b/tests/client/InputHandlerQuickBuildFallback.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  InputHandler,
+  MouseUpEvent,
+  QuickBuildEvent,
+  QuickBuildFailedEvent,
+} from "../../src/client/InputHandler";
+import { EventBus } from "../../src/core/EventBus";
+
+describe("InputHandler quick build fallback", () => {
+  function createPointerEvent(
+    overrides: Partial<PointerEvent> & { x: number; y: number },
+  ): PointerEvent {
+    const base = {
+      button: 0,
+      clientX: overrides.x,
+      clientY: overrides.y,
+      x: overrides.x,
+      y: overrides.y,
+      pointerId: 1,
+      pointerType: "mouse",
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: () => undefined,
+    } as PointerEvent;
+
+    return Object.assign(base, overrides);
+  }
+
+  it("re-emits a normal mouse up when quick build fails", () => {
+    jest.useFakeTimers();
+
+    const canvas = document.createElement("canvas");
+    const eventBus = new EventBus();
+    const handler = new InputHandler(canvas, eventBus);
+    handler.initialize();
+
+    const internal = handler as unknown as {
+      activeKeys: Set<string>;
+      onPointerDown: (event: PointerEvent) => void;
+    };
+
+    const emitSpy = jest.spyOn(eventBus, "emit");
+
+    internal.activeKeys.add("Digit3");
+
+    const pointerDown = createPointerEvent({ x: 100, y: 120 });
+    internal.onPointerDown(pointerDown);
+
+    const pointerUp = createPointerEvent({ x: 100, y: 120 });
+    handler.onPointerUp(pointerUp);
+
+    const quickBuildCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof QuickBuildEvent,
+    );
+    expect(quickBuildCall).toBeDefined();
+
+    eventBus.emit(new QuickBuildFailedEvent(pointerUp.x, pointerUp.y));
+
+    const mouseUpCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof MouseUpEvent,
+    );
+    expect(mouseUpCall).toBeDefined();
+
+    handler.destroy();
+    jest.useRealTimers();
+  });
+});

--- a/tests/client/graphics/BuildMenuQuickBuild.test.ts
+++ b/tests/client/graphics/BuildMenuQuickBuild.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("lit", () => {
+  class MockLitElement {
+    requestUpdate() {}
+  }
+  return {
+    LitElement: MockLitElement,
+    html: () => "",
+    css: () => "",
+  };
+});
+
+jest.mock("lit/decorators.js", () => ({
+  customElement: () => () => undefined,
+  state: () => () => undefined,
+}));
+
+jest.mock("../../../src/client/Transport", () => ({
+  BuildUnitIntentEvent: class BuildUnitIntentEvent {
+    unit: unknown;
+    tile: unknown;
+
+    constructor(unit: unknown, tile: unknown) {
+      this.unit = unit;
+      this.tile = tile;
+    }
+  },
+  SendUpgradeStructureIntentEvent: class SendUpgradeStructureIntentEvent {
+    unitId: unknown;
+    unitType: unknown;
+
+    constructor(unitId: unknown, unitType: unknown) {
+      this.unitId = unitId;
+      this.unitType = unitType;
+    }
+  },
+}));
+
+import { BuildMenu } from "../../../src/client/graphics/layers/BuildMenu";
+import {
+  QuickBuildEvent,
+  QuickBuildFailedEvent,
+} from "../../../src/client/InputHandler";
+import { BuildUnitIntentEvent } from "../../../src/client/Transport";
+import { EventBus } from "../../../src/core/EventBus";
+import {
+  BuildableUnit,
+  PlayerActions,
+  UnitType,
+} from "../../../src/core/game/Game";
+import { TileRef } from "../../../src/core/game/GameMap";
+import { GameView, PlayerView } from "../../../src/core/game/GameView";
+
+describe("BuildMenu quick build", () => {
+  function setupQuickBuildTest(overrides: Partial<BuildableUnit> = {}) {
+    const eventBus = new EventBus();
+    const buildMenu = new BuildMenu();
+    // Prevent Lit from scheduling renders during tests
+    (buildMenu as unknown as { requestUpdate: () => void }).requestUpdate =
+      jest.fn();
+
+    const tile = 321 as TileRef;
+    const buildableUnit: BuildableUnit = {
+      type: overrides.type ?? UnitType.Port,
+      canBuild: overrides.canBuild ?? tile,
+      canUpgrade: overrides.canUpgrade ?? false,
+      cost: overrides.cost ?? 0n,
+    };
+
+    const refMock = jest.fn(() => tile);
+    const actionsMock = jest.fn<Promise<PlayerActions>, [TileRef]>(() =>
+      Promise.resolve({
+        canAttack: false,
+        canSendEmojiAllPlayers: false,
+        buildableUnits: [buildableUnit],
+      }),
+    );
+
+    const player = {
+      isAlive: () => true,
+      actions: actionsMock,
+    } as unknown as PlayerView;
+
+    const game = {
+      myPlayer: () => player,
+      isValidCoord: jest.fn(() => true),
+      ref: refMock,
+      config: () => ({ isUnitDisabled: () => false }),
+    } as unknown as GameView;
+
+    const transformHandler = {
+      screenToWorldCoordinates: jest.fn(() => ({ x: 4, y: 5 })),
+    } as any;
+
+    buildMenu.game = game;
+    buildMenu.eventBus = eventBus;
+    buildMenu.transformHandler = transformHandler;
+
+    buildMenu.init();
+
+    return { eventBus, buildMenu, actionsMock, refMock, tile, buildableUnit };
+  }
+
+  it("emits a build intent when the quick build hotkey is available", async () => {
+    const { eventBus, actionsMock, refMock, tile, buildableUnit } =
+      setupQuickBuildTest();
+
+    const emitSpy = jest.spyOn(eventBus, "emit");
+    eventBus.emit(new QuickBuildEvent(buildableUnit.type, 10, 20));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(actionsMock).toHaveBeenCalledWith(tile);
+    expect(refMock).toHaveBeenCalledWith(4, 5);
+
+    const buildEventCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof BuildUnitIntentEvent,
+    );
+    expect(buildEventCall).toBeDefined();
+    const buildEvent = buildEventCall![0] as BuildUnitIntentEvent;
+    expect(buildEvent.unit).toBe(buildableUnit.type);
+    expect(buildEvent.tile).toBe(tile);
+
+    const failureCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof QuickBuildFailedEvent,
+    );
+    expect(failureCall).toBeUndefined();
+  });
+
+  it("does not emit when the structure cannot be built or upgraded", async () => {
+    const { eventBus, buildableUnit } = setupQuickBuildTest({
+      canBuild: false,
+      canUpgrade: false,
+    });
+
+    const emitSpy = jest.spyOn(eventBus, "emit");
+    eventBus.emit(new QuickBuildEvent(buildableUnit.type, 10, 20));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const buildEventCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof BuildUnitIntentEvent,
+    );
+    expect(buildEventCall).toBeUndefined();
+
+    const failureCall = emitSpy.mock.calls.find(
+      ([event]) => event instanceof QuickBuildFailedEvent,
+    );
+    expect(failureCall).toBeDefined();
+    const failureEvent = failureCall![0] as QuickBuildFailedEvent;
+    expect(failureEvent.x).toBe(10);
+    expect(failureEvent.y).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- add digit 3-9, 0, and H hotkeys that trigger quick build events for structures, the warship, and nukes without opening the menu
- handle quick build requests in the build menu and document the shortcuts in the help modal
- surface quick build failures so the input handler falls back to a normal click when building isn't possible
- cover the quick build workflow and failure fallback with focused unit tests

## Testing
- npm test -- BuildMenuQuickBuild.test.ts InputHandlerQuickBuildFallback.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc7ef3b3f8833396b069998e116008