### PR TITLE
Fix Windows JSON path handling for TypeScript build

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import quickChatData from "../../resources/QuickChat.json" with { type: "json" };
-import countries from "../client/data/countries.json" with { type: "json" };
+import quickChatDataJson from "../../resources/QuickChat.json";
+import countriesJson from "../client/data/countries.json";
 import { PatternSchema } from "./CosmeticSchemas";
 import {
   AllPlayers,
@@ -193,6 +193,21 @@ export const ID = z
 export const AllPlayersStatsSchema = z.record(ID, PlayerStatsSchema);
 
 export const UsernameSchema = SafeString;
+type CountryData = {
+  code: string;
+  restricted?: boolean;
+};
+
+type QuickChatEntry = {
+  key: string;
+  requiresPlayer: boolean;
+};
+
+type QuickChatData = Record<string, QuickChatEntry[]>;
+
+const countries = countriesJson as CountryData[];
+const quickChatData = quickChatDataJson as QuickChatData;
+
 const countryCodes = countries.filter((c) => !c.restricted).map((c) => c.code);
 export const FlagSchema = z
   .string()

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,3 +40,8 @@ declare module "*.xml" {
   const value: string;
   export default value;
 }
+
+declare module "*.json" {
+  const value: any;
+  export default value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "resolveJsonModule": true,
     "strictNullChecks": true,
     "useDefineForClassFields": false,
     "strictPropertyInitialization": false


### PR DESCRIPTION
## Summary
- remove TypeScript's resolveJsonModule option to avoid Windows path normalization issues when loading JSON
- add a JSON module declaration and cast imported QuickChat and country data to keep the existing runtime behavior

## Testing
- npm run build-dev
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdcdfe71208333b52faf605bdf4735