### PR TITLE
Enhance cluster rocket behavior and add MIRV shortcut

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -158,6 +158,7 @@ export class InputHandler {
     ["Digit9", UnitType.Warship],
     ["Digit0", UnitType.AtomBomb],
     ["KeyH", UnitType.HydrogenBomb],
+    ["KeyM", UnitType.MIRV],
     ["KeyJ", UnitType.ClusterRocket],
     ["KeyK", UnitType.TacticalRocket],
     ["KeyL", UnitType.MissileShip],

--- a/src/client/graphics/layers/FxLayer.ts
+++ b/src/client/graphics/layers/FxLayer.ts
@@ -228,7 +228,7 @@ export class FxLayer implements Layer {
       if (!unit.reachedTarget()) {
         this.handleSAMInterception(unit);
       } else {
-        this.spawnMiniExplosion(unit.lastTile(), false);
+        this.spawnMiniExplosion(unit.tile(), false);
       }
     }
   }

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -123,6 +123,7 @@ export class UILayer implements Layer {
       }
       case UnitType.MissileShip: {
         this.drawHealthBar(unit);
+        this.createLoadingBar(unit);
         break;
       }
       case UnitType.MissileSilo:

--- a/src/core/execution/RocketExecution.ts
+++ b/src/core/execution/RocketExecution.ts
@@ -3,6 +3,7 @@ import {
   Game,
   isStructureType,
   Player,
+  TerraNullius,
   TrajectoryTile,
   Unit,
   UnitType,
@@ -20,15 +21,17 @@ type RocketConfig = {
   troopDamage: number;
   bursts: { min: number; max: number };
   spread: number;
+  minClusterSpacing?: number;
 };
 
 const rocketConfig: Record<RocketUnitType, RocketConfig> = {
   [UnitType.ClusterRocket]: {
     speed: 8,
-    blastRadius: 1,
-    troopDamage: 300,
-    bursts: { min: 5, max: 10 },
-    spread: 6,
+    blastRadius: 0,
+    troopDamage: 200,
+    bursts: { min: 7, max: 12 },
+    spread: 18,
+    minClusterSpacing: 6,
   },
   [UnitType.TacticalRocket]: {
     speed: 12,
@@ -174,30 +177,36 @@ export class RocketExecution implements Execution {
       blasts.push(tile);
     };
 
-    addBlast(this.dst);
-
     const totalBlasts = this.randomBurstCount(config);
-    const baseX = this.mg.x(this.dst);
-    const baseY = this.mg.y(this.dst);
+    if (this.rocketType === UnitType.ClusterRocket) {
+      const clusterTargets = this.generateClusterBlasts(config, totalBlasts);
+      for (const target of clusterTargets) {
+        addBlast(target);
+      }
+    } else {
+      addBlast(this.dst);
+      const baseX = this.mg.x(this.dst);
+      const baseY = this.mg.y(this.dst);
 
-    if (config.spread > 0) {
-      let attempts = 0;
-      const maxAttempts = totalBlasts * 8;
-      while (blasts.length < totalBlasts && attempts < maxAttempts) {
-        attempts++;
-        const distance = this.random.nextFloat(0, config.spread);
-        const angle = this.random.nextFloat(0, Math.PI * 2);
-        const offsetX = Math.round(Math.cos(angle) * distance);
-        const offsetY = Math.round(Math.sin(angle) * distance);
-        if (offsetX === 0 && offsetY === 0) {
-          continue;
+      if (config.spread > 0) {
+        let attempts = 0;
+        const maxAttempts = totalBlasts * 8;
+        while (blasts.length < totalBlasts && attempts < maxAttempts) {
+          attempts++;
+          const distance = this.random.nextFloat(0, config.spread);
+          const angle = this.random.nextFloat(0, Math.PI * 2);
+          const offsetX = Math.round(Math.cos(angle) * distance);
+          const offsetY = Math.round(Math.sin(angle) * distance);
+          if (offsetX === 0 && offsetY === 0) {
+            continue;
+          }
+          const x = baseX + offsetX;
+          const y = baseY + offsetY;
+          if (!this.mg.isValidCoord(x, y)) {
+            continue;
+          }
+          addBlast(this.mg.ref(x, y));
         }
-        const x = baseX + offsetX;
-        const y = baseY + offsetY;
-        if (!this.mg.isValidCoord(x, y)) {
-          continue;
-        }
-        addBlast(this.mg.ref(x, y));
       }
     }
 
@@ -278,6 +287,107 @@ export class RocketExecution implements Execution {
       return Math.max(min, 1);
     }
     return this.random.nextInt(min, max + 1);
+  }
+
+  private generateClusterBlasts(
+    config: RocketConfig,
+    desiredBlasts: number,
+  ): TileRef[] {
+    const blasts: TileRef[] = [];
+    const seen = new Set<TileRef>();
+
+    const baseX = this.mg.x(this.dst);
+    const baseY = this.mg.y(this.dst);
+    const preferLand = this.mg.isLand(this.dst);
+    const targetOwner = this.mg.hasOwner(this.dst)
+      ? this.mg.owner(this.dst)
+      : null;
+
+    const minSpacing = Math.max(
+      2,
+      config.minClusterSpacing ?? Math.floor(Math.max(config.spread, 1) / 3),
+    );
+    const maxAttempts = desiredBlasts * 50;
+
+    const addIfValid = (tile: TileRef | null) => {
+      if (tile === null) {
+        return false;
+      }
+      if (seen.has(tile)) {
+        return false;
+      }
+      if (
+        blasts.some(
+          (existing) => this.mg.manhattanDist(existing, tile) < minSpacing,
+        )
+      ) {
+        return false;
+      }
+      seen.add(tile);
+      blasts.push(tile);
+      return true;
+    };
+
+    addIfValid(this.dst);
+
+    let attempts = 0;
+    while (blasts.length < desiredBlasts && attempts < maxAttempts) {
+      attempts++;
+      const candidate = this.randomClusterTarget(
+        baseX,
+        baseY,
+        config.spread,
+        targetOwner,
+        preferLand,
+      );
+      addIfValid(candidate);
+    }
+
+    if (blasts.length === 0) {
+      blasts.push(this.dst);
+    }
+
+    return blasts;
+  }
+
+  private randomClusterTarget(
+    baseX: number,
+    baseY: number,
+    spread: number,
+    targetOwner: Player | TerraNullius | null,
+    preferLand: boolean,
+  ): TileRef | null {
+    if (spread <= 0) {
+      return this.dst;
+    }
+
+    const minX = baseX - spread;
+    const maxX = baseX + spread;
+    const minY = baseY - spread;
+    const maxY = baseY + spread;
+    const maxLocalAttempts = 60;
+
+    for (let tries = 0; tries < maxLocalAttempts; tries++) {
+      const x = this.random.nextInt(minX, maxX + 1);
+      const y = this.random.nextInt(minY, maxY + 1);
+      if (!this.mg.isValidCoord(x, y)) {
+        continue;
+      }
+      const tile = this.mg.ref(x, y);
+      if (preferLand && !this.mg.isLand(tile)) {
+        continue;
+      }
+      if (
+        targetOwner !== null &&
+        targetOwner.isPlayer() &&
+        (!this.mg.hasOwner(tile) || this.mg.owner(tile) !== targetOwner)
+      ) {
+        continue;
+      }
+      return tile;
+    }
+
+    return null;
   }
 
   private findCarrier(spawn: TileRef): Unit | null {


### PR DESCRIPTION
## Summary
- rework cluster rocket payload generation to mirror MIRV-style dispersal with wider spread and lighter blasts
- show missile ship reload progress and align tactical rocket impact effects with their targets
- add a quick-build hotkey for MIRV launches

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd5a81e748333a48da8136a6be0af