### PR TITLE
Rework cluster rocket into MIRV-style bomblets

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -158,6 +158,7 @@ export class InputHandler {
     ["Digit9", UnitType.Warship],
     ["Digit0", UnitType.AtomBomb],
     ["KeyH", UnitType.HydrogenBomb],
+    ["KeyM", UnitType.MIRV],
     ["KeyJ", UnitType.ClusterRocket],
     ["KeyK", UnitType.TacticalRocket],
     ["KeyL", UnitType.MissileShip],

--- a/src/client/graphics/layers/FxLayer.ts
+++ b/src/client/graphics/layers/FxLayer.ts
@@ -228,7 +228,7 @@ export class FxLayer implements Layer {
       if (!unit.reachedTarget()) {
         this.handleSAMInterception(unit);
       } else {
-        this.spawnMiniExplosion(unit.lastTile(), false);
+        this.spawnMiniExplosion(unit.tile(), false);
       }
     }
   }
@@ -259,17 +259,21 @@ export class FxLayer implements Layer {
 
   private handleClusterExplosion(unit: UnitView) {
     const payloadTiles = unit.payloadTiles();
+    if (payloadTiles !== undefined && payloadTiles.length === 0) {
+      return;
+    }
     const tiles =
       payloadTiles !== undefined && payloadTiles.length > 0
         ? payloadTiles
         : [unit.lastTile()];
+    const includeSmoke = payloadTiles !== undefined && payloadTiles.length > 1;
     const seen = new Set<TileRef>();
     for (const tile of tiles) {
       if (seen.has(tile)) {
         continue;
       }
       seen.add(tile);
-      this.spawnMiniExplosion(tile, true);
+      this.spawnMiniExplosion(tile, includeSmoke);
     }
   }
 

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -123,6 +123,7 @@ export class UILayer implements Layer {
       }
       case UnitType.MissileShip: {
         this.drawHealthBar(unit);
+        this.createLoadingBar(unit);
         break;
       }
       case UnitType.MissileSilo:
@@ -337,6 +338,7 @@ export class UILayer implements Layer {
 
       case UnitType.MissileSilo:
       case UnitType.SAMLauncher:
+      case UnitType.MissileShip:
         return unit.missileReadinesss();
       default:
         return 1;

--- a/src/core/execution/RocketExecution.ts
+++ b/src/core/execution/RocketExecution.ts
@@ -3,6 +3,7 @@ import {
   Game,
   isStructureType,
   Player,
+  TerraNullius,
   TrajectoryTile,
   Unit,
   UnitType,
@@ -20,15 +21,27 @@ type RocketConfig = {
   troopDamage: number;
   bursts: { min: number; max: number };
   spread: number;
+  minClusterSpacing?: number;
 };
+
+interface RocketExecutionOptions {
+  skipSpawnChecks?: boolean;
+  skipLaunchCooldown?: boolean;
+  skipCost?: boolean;
+  skipStats?: boolean;
+  isClusterBomblet?: boolean;
+}
+
+const CLUSTER_BOMBLET_COUNT = 5;
 
 const rocketConfig: Record<RocketUnitType, RocketConfig> = {
   [UnitType.ClusterRocket]: {
     speed: 8,
     blastRadius: 1,
-    troopDamage: 300,
-    bursts: { min: 5, max: 10 },
-    spread: 6,
+    troopDamage: 350,
+    bursts: { min: 3, max: 5 },
+    spread: 26,
+    minClusterSpacing: 10,
   },
   [UnitType.TacticalRocket]: {
     speed: 12,
@@ -52,6 +65,7 @@ export class RocketExecution implements Execution {
     private player: Player,
     private readonly dst: TileRef,
     private src?: TileRef | null,
+    private readonly options: RocketExecutionOptions = {},
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -62,34 +76,60 @@ export class RocketExecution implements Execution {
 
   tick(ticks: number): void {
     if (this.rocket === null) {
-      const spawn = this.src ?? this.player.canBuild(this.rocketType, this.dst);
+      let spawn: TileRef | false;
+      if (this.options.skipSpawnChecks) {
+        if (this.src === undefined || this.src === null) {
+          console.warn(`missing spawn tile for rocket ${this.rocketType}`);
+          this.active = false;
+          return;
+        }
+        spawn = this.src;
+      } else {
+        spawn = this.src ?? this.player.canBuild(this.rocketType, this.dst);
+        if (spawn === false) {
+          console.warn(`cannot build rocket ${this.rocketType}`);
+          this.active = false;
+          return;
+        }
+      }
       if (spawn === false) {
-        console.warn(`cannot build rocket ${this.rocketType}`);
+        console.warn(`cannot determine spawn for rocket ${this.rocketType}`);
         this.active = false;
         return;
       }
       this.src = spawn;
-      this.carrier ??= this.findCarrier(spawn);
-      if (this.carrier === null) {
-        console.warn(`no missile ship available for ${this.rocketType}`);
-        this.active = false;
-        return;
-      }
-      if (this.carrier.isInCooldown()) {
-        console.warn(`missile ship on cooldown for ${this.rocketType}`);
-        this.active = false;
-        return;
+      if (!this.options.skipSpawnChecks) {
+        this.carrier ??= this.findCarrier(spawn);
+        if (this.carrier === null) {
+          console.warn(`no missile ship available for ${this.rocketType}`);
+          this.active = false;
+          return;
+        }
+        if (this.carrier.isInCooldown()) {
+          console.warn(`missile ship on cooldown for ${this.rocketType}`);
+          this.active = false;
+          return;
+        }
       }
       const config = rocketConfig[this.rocketType];
       this.pathFinder.computeControlPoints(spawn, this.dst, config.speed, true);
+      const goldBefore = this.player.gold();
       this.rocket = this.player.buildUnit(this.rocketType, spawn, {
         targetTile: this.dst,
         trajectory: this.getTrajectory(this.dst),
       });
+      if (this.options.skipCost) {
+        const spentGold = goldBefore - this.player.gold();
+        if (spentGold > 0n) {
+          this.player.addGold(spentGold);
+        }
+      }
 
-      this.carrier.launch();
+      if (!this.options.skipLaunchCooldown && this.carrier !== null) {
+        this.carrier.launch();
+      }
 
-      if (this.mg.hasOwner(this.dst)) {
+      if (!this.options.skipStats && this.mg.hasOwner(this.dst)) {
         const target = this.mg.owner(this.dst);
         if (target.isPlayer()) {
           this.mg
@@ -164,6 +204,15 @@ export class RocketExecution implements Execution {
     }
 
     const config = rocketConfig[this.rocketType];
+
+    if (
+      this.rocketType === UnitType.ClusterRocket &&
+      !this.options.isClusterBomblet
+    ) {
+      this.splitClusterRocket(config);
+      return;
+    }
+
     const blasts: TileRef[] = [];
     const seen = new Set<TileRef>();
     const addBlast = (tile: TileRef) => {
@@ -174,30 +223,33 @@ export class RocketExecution implements Execution {
       blasts.push(tile);
     };
 
-    addBlast(this.dst);
+    if (this.rocketType === UnitType.ClusterRocket) {
+      addBlast(this.dst);
+    } else {
+      addBlast(this.dst);
+      const baseX = this.mg.x(this.dst);
+      const baseY = this.mg.y(this.dst);
 
-    const totalBlasts = this.randomBurstCount(config);
-    const baseX = this.mg.x(this.dst);
-    const baseY = this.mg.y(this.dst);
-
-    if (config.spread > 0) {
-      let attempts = 0;
-      const maxAttempts = totalBlasts * 8;
-      while (blasts.length < totalBlasts && attempts < maxAttempts) {
-        attempts++;
-        const distance = this.random.nextFloat(0, config.spread);
-        const angle = this.random.nextFloat(0, Math.PI * 2);
-        const offsetX = Math.round(Math.cos(angle) * distance);
-        const offsetY = Math.round(Math.sin(angle) * distance);
-        if (offsetX === 0 && offsetY === 0) {
-          continue;
+      if (config.spread > 0) {
+        const totalBlasts = this.randomBurstCount(config);
+        let attempts = 0;
+        const maxAttempts = totalBlasts * 8;
+        while (blasts.length < totalBlasts && attempts < maxAttempts) {
+          attempts++;
+          const distance = this.random.nextFloat(0, config.spread);
+          const angle = this.random.nextFloat(0, Math.PI * 2);
+          const offsetX = Math.round(Math.cos(angle) * distance);
+          const offsetY = Math.round(Math.sin(angle) * distance);
+          if (offsetX === 0 && offsetY === 0) {
+            continue;
+          }
+          const x = baseX + offsetX;
+          const y = baseY + offsetY;
+          if (!this.mg.isValidCoord(x, y)) {
+            continue;
+          }
+          addBlast(this.mg.ref(x, y));
         }
-        const x = baseX + offsetX;
-        const y = baseY + offsetY;
-        if (!this.mg.isValidCoord(x, y)) {
-          continue;
-        }
-        addBlast(this.mg.ref(x, y));
       }
     }
 
@@ -216,7 +268,7 @@ export class RocketExecution implements Execution {
     this.rocket.setReachedTarget();
     this.rocket.delete(false);
 
-    if (this.mg.hasOwner(this.dst)) {
+    if (!this.options.skipStats && this.mg.hasOwner(this.dst)) {
       const target = this.mg.owner(this.dst);
       if (target.isPlayer()) {
         this.mg
@@ -278,6 +330,222 @@ export class RocketExecution implements Execution {
       return Math.max(min, 1);
     }
     return this.random.nextInt(min, max + 1);
+  }
+
+  private splitClusterRocket(config: RocketConfig) {
+    if (this.rocket === null) {
+      throw new Error("Rocket not initialized");
+    }
+
+    const origin = this.rocket.tile();
+    const clusterTargets = this.generateClusterBlasts(
+      config,
+      CLUSTER_BOMBLET_COUNT,
+    );
+
+    for (const target of clusterTargets) {
+      this.mg.addExecution(
+        new RocketExecution(
+          UnitType.ClusterRocket,
+          this.player,
+          target,
+          origin,
+          {
+            skipSpawnChecks: true,
+            skipLaunchCooldown: true,
+            skipCost: true,
+            skipStats: true,
+            isClusterBomblet: true,
+          },
+        ),
+      );
+    }
+
+    this.active = false;
+    this.rocket.setPayloadTiles([]);
+    this.rocket.setReachedTarget();
+    this.rocket.delete(false);
+    this.rocket = null;
+
+    if (!this.options.skipStats && this.mg.hasOwner(this.dst)) {
+      const target = this.mg.owner(this.dst);
+      if (target.isPlayer()) {
+        this.mg
+          .stats()
+          .bombLand(this.player, target, this.rocketType as NukeType);
+      }
+    }
+  }
+
+  private generateClusterBlasts(
+    config: RocketConfig,
+    desiredBlasts: number,
+  ): TileRef[] {
+    const blasts: TileRef[] = [];
+    const seen = new Set<TileRef>();
+
+    const baseX = this.mg.x(this.dst);
+    const baseY = this.mg.y(this.dst);
+    const preferLand = this.mg.isLand(this.dst);
+    const targetOwner = this.mg.hasOwner(this.dst)
+      ? this.mg.owner(this.dst)
+      : null;
+
+    const minSpacing = Math.max(
+      4,
+      config.minClusterSpacing ?? Math.floor(Math.max(config.spread, 1) / 3),
+    );
+    const minSpacingSquared = minSpacing * minSpacing;
+    const maxAttempts = Math.max(20, desiredBlasts * 60);
+
+    const addIfValid = (tile: TileRef | null, enforceSpacing = true) => {
+      if (tile === null) {
+        return false;
+      }
+      if (seen.has(tile)) {
+        return false;
+      }
+      if (
+        enforceSpacing &&
+        blasts.some(
+          (existing) =>
+            this.mg.euclideanDistSquared(existing, tile) < minSpacingSquared,
+        )
+      ) {
+        return false;
+      }
+      seen.add(tile);
+      blasts.push(tile);
+      return true;
+    };
+
+    addIfValid(this.dst, false);
+
+    if (targetOwner !== null && targetOwner.isPlayer()) {
+      const playerOwner = targetOwner;
+      const maxDistanceSquared =
+        config.spread > 0
+          ? config.spread * config.spread
+          : Number.POSITIVE_INFINITY;
+      const ownerTargets: TileRef[] = [];
+      for (const unit of this.mg.units()) {
+        if (!unit.isActive() || unit.owner() !== playerOwner) {
+          continue;
+        }
+        if (
+          unit.type() === UnitType.ClusterRocket ||
+          unit.type() === UnitType.TacticalRocket ||
+          unit.type() === UnitType.MIRVWarhead ||
+          unit.type() === UnitType.MIRV
+        ) {
+          continue;
+        }
+        if (
+          config.spread > 0 &&
+          this.mg.euclideanDistSquared(unit.tile(), this.dst) >
+            maxDistanceSquared
+        ) {
+          continue;
+        }
+        ownerTargets.push(unit.tile());
+      }
+
+      ownerTargets.sort(
+        (a, b) =>
+          this.mg.euclideanDistSquared(b, this.dst) -
+          this.mg.euclideanDistSquared(a, this.dst),
+      );
+
+      for (const tile of ownerTargets) {
+        if (blasts.length >= desiredBlasts) {
+          break;
+        }
+        addIfValid(tile);
+      }
+    }
+
+    let attempts = 0;
+    while (blasts.length < desiredBlasts && attempts < maxAttempts) {
+      attempts++;
+      const ignoreOwner = attempts > maxAttempts / 2;
+      const candidate = this.randomClusterTarget(
+        baseX,
+        baseY,
+        config.spread,
+        ignoreOwner ? null : targetOwner,
+        preferLand,
+      );
+      addIfValid(candidate);
+    }
+
+    if (blasts.length < desiredBlasts) {
+      let fallbackAttempts = maxAttempts;
+      while (blasts.length < desiredBlasts && fallbackAttempts > 0) {
+        fallbackAttempts--;
+        const ignoreOwner = fallbackAttempts < maxAttempts / 2;
+        const candidate = this.randomClusterTarget(
+          baseX,
+          baseY,
+          config.spread,
+          ignoreOwner ? null : targetOwner,
+          preferLand,
+        );
+        addIfValid(candidate, false);
+      }
+    }
+
+    if (blasts.length === 0) {
+      blasts.push(this.dst);
+    }
+
+    return blasts;
+  }
+
+  private randomClusterTarget(
+    baseX: number,
+    baseY: number,
+    spread: number,
+    targetOwner: Player | TerraNullius | null,
+    preferLand: boolean,
+  ): TileRef | null {
+    if (spread <= 0) {
+      return this.dst;
+    }
+
+    const minX = baseX - spread;
+    const maxX = baseX + spread;
+    const minY = baseY - spread;
+    const maxY = baseY + spread;
+    const maxLocalAttempts = 80;
+    const maxDistanceSquared = spread * spread;
+
+    for (let tries = 0; tries < maxLocalAttempts; tries++) {
+      const x = this.random.nextInt(minX, maxX + 1);
+      const y = this.random.nextInt(minY, maxY + 1);
+      if (!this.mg.isValidCoord(x, y)) {
+        continue;
+      }
+      const tile = this.mg.ref(x, y);
+      if (preferLand && !this.mg.isLand(tile)) {
+        continue;
+      }
+      if (
+        spread > 0 &&
+        this.mg.euclideanDistSquared(tile, this.dst) > maxDistanceSquared
+      ) {
+        continue;
+      }
+      if (
+        targetOwner !== null &&
+        targetOwner.isPlayer() &&
+        (!this.mg.hasOwner(tile) || this.mg.owner(tile) !== targetOwner)
+      ) {
+        continue;
+      }
+      return tile;
+    }
+
+    return null;
   }
 
   private findCarrier(spawn: TileRef): Unit | null {


### PR DESCRIPTION
## Summary
- update the cluster rocket execution so the primary missile splits mid-air into five bomblets that launch as separate rockets while skipping extra cost, cooldown, and stat bookkeeping
- reuse the tactical-style mini explosions for cluster payloads by skipping smoke on single-tile payloads and ignoring empty payload updates
- surface missile ship reload progress through the existing loading bar logic by reusing missile readiness calculations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd5a81e748333a48da8136a6be0af