### PR TITLE
Enable missile warships to fire single-shell volleys

### DIFF
--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -126,7 +126,7 @@ export class ConstructionExecution implements Execution {
         this.mg.addExecution(
           new WarshipExecution(
             { owner: player, patrolTile: this.tile },
-            { unitType: UnitType.MissileShip, allowShells: false },
+            { unitType: UnitType.MissileShip, shellVolleySize: 1 },
           ),
         );
         break;

--- a/tests/RocketExecution.test.ts
+++ b/tests/RocketExecution.test.ts
@@ -89,7 +89,7 @@ function prepareMissileShip(): {
   game.addExecution(
     new WarshipExecution(missileShip, {
       unitType: UnitType.MissileShip,
-      allowShells: false,
+      shellVolleySize: 1,
     }),
   );
   return {


### PR DESCRIPTION
## Summary
- allow `WarshipExecution` to control the number of shells fired per attack volley and default missile ships to a single shot
- enable missile ships spawned through construction to fire shells and update the rocket execution fixture accordingly
- extend the warship tests to cover volley behaviour for normal and missile ships

## Testing
- npm test -- Warship
- npm test -- RocketExecution

------
https://chatgpt.com/codex/tasks/task_e_68ce8e19ffac833386072cc4e455c72c