### PR TITLE
Enable missile warships to fire single-shell volleys

### DIFF
--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -126,7 +126,7 @@ export class ConstructionExecution implements Execution {
         this.mg.addExecution(
           new WarshipExecution(
             { owner: player, patrolTile: this.tile },
-            { unitType: UnitType.MissileShip, allowShells: false },
+            { unitType: UnitType.MissileShip, shellVolleySize: 1 },
           ),
         );
         break;

--- a/src/core/execution/RocketExecution.ts
+++ b/src/core/execution/RocketExecution.ts
@@ -77,26 +77,24 @@ export class RocketExecution implements Execution {
 
   tick(ticks: number): void {
     if (this.rocket === null) {
-      let spawn: TileRef | false;
+      let spawn: TileRef;
       if (this.options.skipSpawnChecks) {
-        if (this.src === undefined || this.src === null) {
+        const source = this.src;
+        if (source === undefined || source === null) {
           console.warn(`missing spawn tile for rocket ${this.rocketType}`);
           this.active = false;
           return;
         }
-        spawn = this.src;
+        spawn = source;
       } else {
-        spawn = this.src ?? this.player.canBuild(this.rocketType, this.dst);
-        if (spawn === false) {
+        const spawnResult =
+          this.src ?? this.player.canBuild(this.rocketType, this.dst);
+        if (spawnResult === false) {
           console.warn(`cannot build rocket ${this.rocketType}`);
           this.active = false;
           return;
         }
-      }
-      if (spawn === false) {
-        console.warn(`cannot determine spawn for rocket ${this.rocketType}`);
-        this.active = false;
-        return;
+        spawn = spawnResult;
       }
       this.src = spawn;
       if (!this.options.skipSpawnChecks) {

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -698,6 +698,7 @@ export interface Game extends GameMap {
     predicate?: UnitPredicate,
   ): Array<{ unit: Unit; distSquared: number }>;
 
+  executions(): Execution[];
   addExecution(...exec: Execution[]): void;
   displayMessage(
     message: string,

--- a/tests/RocketExecution.test.ts
+++ b/tests/RocketExecution.test.ts
@@ -89,7 +89,7 @@ function prepareMissileShip(): {
   game.addExecution(
     new WarshipExecution(missileShip, {
       unitType: UnitType.MissileShip,
-      allowShells: false,
+      shellVolleySize: 1,
     }),
   );
   return {


### PR DESCRIPTION
## Summary
- allow `WarshipExecution` to control the number of shells fired per attack volley and default missile ships to a single shot
- enable missile ships spawned through construction to fire shells and update the rocket execution fixture accordingly
- extend the warship tests to cover volley behaviour for normal and missile ships
- fix rocket spawn validation to avoid false comparisons and expose `Game.executions()` for the tests

## Testing
- npm test -- Warship
- npm test -- RocketExecution

------
https://chatgpt.com/codex/tasks/task_e_68ce8e19ffac833386072cc4e455c72c